### PR TITLE
git pull is no good after doing rebase upstream

### DIFF
--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -11,7 +11,9 @@ class DockerManager::Upgrader
   end
 
   def upgrade
-    run("cd #{path} && git pull")
+    # HEAD@{upstream} is just a fancy way how to say origin/master (in normal case)
+    # see http://stackoverflow.com/a/12699604/84283
+    run("cd #{path} && git fetch && git reset --hard HEAD@{upstream}")
     run("bundle install --deployment --without test --without development")
     run("bundle exec rake db:migrate")
     run("bundle exec rake assets:precompile")


### PR DESCRIPTION
More generally, when you rewrite history in upstream, git will try to merge.
Not only that merging could fail with conflicts, but it also needs git username.

This was my log shown at http://{mydiscourse.com}/admin/docker when doing upgrade:

```
$ cd /var/www/discourse && git pull
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident   not allowed
```

a side note: my failing repo is [here](https://github.com/binaryage/discourse). You can see that I'm using rebase to roll my patch on top of discourse master.
