### PR TITLE
Render the version numbers as JSON.

### DIFF
--- a/app/controllers/docker_manager/admin_controller.rb
+++ b/app/controllers/docker_manager/admin_controller.rb
@@ -75,8 +75,8 @@ module DockerManager
     def versions
       # Get the different version numbers of the programs used
       render json: {versions: {ruby: "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}",
-                                postgresql: "postmaster -V",
-                                redis: "redis-server --version"}}
+                                postgresql: `postmaster -V`,
+                                redis: `redis-server --version`}}
     end
 
     def runaway_cpu

--- a/app/controllers/docker_manager/admin_controller.rb
+++ b/app/controllers/docker_manager/admin_controller.rb
@@ -72,6 +72,13 @@ module DockerManager
       render text: ps_output
     end
 
+    def versions
+      # Get the different version numbers of the programs used
+      render json: {versions: {ruby: "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}",
+                                postgresql: "postmaster -V",
+                                redis: "redis-server --version"}}
+    end
+
     def runaway_cpu
       Thread.new do
         a = 1


### PR DESCRIPTION
Render the version numbers as JSON object. Uses the backticks now to properly execute the version commands.