### PR TITLE
FEATURE: Support Plugin Branches instead of assuming master

### DIFF
--- a/lib/docker_manager/git_repo.rb
+++ b/lib/docker_manager/git_repo.rb
@@ -6,9 +6,7 @@ class DockerManager::GitRepo
     @path = path
     @name = name
     @memoize = {}
-
-    # For discourse proper, return tracking branch
-    @branch = (path == Rails.root.to_s) ? tracking_branch : 'master'
+    @branch = tracking_branch
   end
 
   def start_upgrading


### PR DESCRIPTION
per https://meta.discourse.org/t/docker-upgrade-links-point-only-to-the-repo-not-the-displayed-commit/20016/31?u=cpradio

This works because it is running a git command in the plugin repos folder (which it is already running to get the number of commits it is behind anyway). So this simply permits the compare link to reference the branch the discourse instance may be pointing to.