### PR TITLE
FIX: Add --tags to git fetch in updater

### DIFF
--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -20,7 +20,7 @@ class DockerManager::Upgrader
 
     # HEAD@{upstream} is just a fancy way how to say origin/master (in normal case)
     # see http://stackoverflow.com/a/12699604/84283
-    run("cd #{@repo.path} && git fetch && git reset --hard HEAD@{upstream}")
+    run("cd #{@repo.path} && git fetch --tags && git reset --hard HEAD@{upstream}")
     log("********************************************************")
     log("*** Please be patient, next steps might take a while ***")
     log("********************************************************")


### PR DESCRIPTION
Overwrites local tags with those from github (useful if they've been changed on github)

From https://git-scm.com/docs/git-fetch#git-fetch---tags
```
--tags
    Fetch all tags from the remote (i.e., fetch remote tags refs/tags/* into local tags 
    with the same name), in addition to whatever else would otherwise be fetched.
```
See https://meta.discourse.org/t/latest-version-bug/58165