### PR TITLE
Add `html_safe` to raw HTML string

### DIFF
--- a/app/controllers/docker_manager/admin_controller.rb
+++ b/app/controllers/docker_manager/admin_controller.rb
@@ -17,7 +17,7 @@ module DockerManager
 
       if (version < expected_version) || (ruby_version < expected_ruby_version)
 
-        render html: <<~HTML
+        message = <<~HTML
         <html><head></head><body>
         <h2>You are running an old version of the Discourse image.</h2>
         <p>
@@ -38,6 +38,8 @@ module DockerManager
         </body>
         </html>
         HTML
+
+        render html: message.html_safe
       else
         render
       end


### PR DESCRIPTION
> When using html: option, HTML entities will be escaped if the string is not marked as HTML safe by using html_safe method.

(section 2.2.7 http://guides.rubyonrails.org/layouts_and_rendering.html)

See https://meta.discourse.org/t/docker-manager-old-image-message-is-showing-raw-html/79400