### PR TITLE
FIX: Allow requests with API keys

### DIFF
--- a/app/controllers/docker_manager/application_controller.rb
+++ b/app/controllers/docker_manager/application_controller.rb
@@ -7,9 +7,11 @@ module DockerManager
     protect_from_forgery
 
     def handle_unverified_request
-      super
-      clear_current_user
-      render plain: "['BAD CSRF']", status: 403
+      unless is_api?
+        super
+        clear_current_user
+        render plain: "['BAD CSRF']", status: 403
+      end
     end
 
   end


### PR DESCRIPTION
Issue: https://meta.discourse.org/t/run-upgrade-all-from-the-command-line/109872/5

I don't have a great way to verify this change, but it matches what has been done at https://github.com/yanokwa/discourse/blob/master/app/controllers/application_controller.rb#L34.

So changes that I considered but didn't make because I wanted to make the most narrow change I understood:
* Use`unless is_api? || is_user_api?` instead of `is_api`
* Change the output to: `"[\"BAD CSRF\"]"`