### PR TITLE
Fix message bus when using a longPollingBaseUrl

### DIFF
--- a/manager-client/app/initializers/message-bus.js
+++ b/manager-client/app/initializers/message-bus.js
@@ -4,7 +4,7 @@ export default {
   name: "message-bus",
 
   initialize() {
-    MessageBus.baseUrl = Discourse.longPollingBaseUrl + "/";
+    MessageBus.baseUrl = Discourse.longPollingBaseUrl.replace(/\/$/, "") + "/";
 
     if (MessageBus.baseUrl !== "/") {
       MessageBus.ajax = function(opts) {

--- a/manager-client/app/initializers/message-bus.js
+++ b/manager-client/app/initializers/message-bus.js
@@ -4,7 +4,7 @@ export default {
   name: "message-bus",
 
   initialize() {
-    MessageBus.baseUrl = Discourse.longPollingBaseUrl;
+    MessageBus.baseUrl = Discourse.longPollingBaseUrl + "/";
 
     if (MessageBus.baseUrl !== "/") {
       MessageBus.ajax = function(opts) {


### PR DESCRIPTION
The trailing slash was missing from the longPollingBaseUrl causing the messageBus to fail.
So I just added the trailing slash :)