### PR TITLE
FEATURE: Attempt to flush nginx service worker cache on upgrade

### DIFF
--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -89,6 +89,7 @@ class DockerManager::Upgrader
     begin
       run("bundle exec rake assets:flush_sw")
     rescue
+      log "WARNING: Unable to flush service worker file"
     end
 
     percent(90)

--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -88,7 +88,7 @@ class DockerManager::Upgrader
     percent(85)
     begin
       run("bundle exec rake assets:flush_sw")
-    rescue
+    rescue RuntimeError
       log "WARNING: Unable to flush service worker file"
     end
 

--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -84,6 +84,13 @@ class DockerManager::Upgrader
     reload_unicorn(launcher_pid)
     reloaded = true
 
+    # Flush nginx cache here - this is not critical, and the rake task may not exist yet - ignore failures here.
+    percent(85)
+    begin
+      run("bundle exec rake assets:flush_sw")
+    rescue
+    end
+
     percent(90)
     log("Running post deploy migrations")
     run("bundle exec rake multisite:migrate")


### PR DESCRIPTION
Flush is done via rake task.

This takes advantage of the rake task proposed here to flush the service worker cache: https://github.com/discourse/discourse/pull/8359