### PR TITLE
Add plugin compat checkout updates

### DIFF
--- a/lib/docker_manager/git_repo.rb
+++ b/lib/docker_manager/git_repo.rb
@@ -113,7 +113,7 @@ class DockerManager::GitRepo
   end
 
   def tracking_branch
-    run "for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)"
+    Discourse.find_compatible_git_resource(path) || run("for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)")
   end
 
   def run(cmd)

--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -73,6 +73,11 @@ class DockerManager::Upgrader
     end
 
     run("bundle install --deployment --jobs 4 --without test development")
+    begin
+      run("bundle exec rake plugin:pull_compatible_all")
+    rescue RuntimeError
+      log "Unable checkout compatible plugin versions"
+    end
     percent(30)
     run("SKIP_POST_DEPLOYMENT_MIGRATIONS=1 bundle exec rake multisite:migrate")
     percent(40)


### PR DESCRIPTION
use rake tasks to pull compatible plugins from https://github.com/discourse/discourse/pull/9995