### PR TITLE
FIX: Use imported getURL

### DIFF
--- a/assets/javascripts/discourse/components/upgrade-notice.js.es6
+++ b/assets/javascripts/discourse/components/upgrade-notice.js.es6
@@ -1,6 +1,8 @@
+import getURL from "discourse-common/lib/get-url";
+
 export default Ember.Component.extend({
   tagName: "tr",
   href: function() {
-    return Discourse.getAppURL("/admin/upgrade");
+    return getURL("/admin/upgrade");
   }.property()
 });


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/dashboard-broken-after-2-6-0-beta1-install-removing-docker-manager-fixes-it/156963/