### PR TITLE
FIX: upgrade requests shouldn't timeout

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module DockerManager::ApplicationHelper
   def discourse_root_url
-    Discourse.base_uri
+    Discourse.base_path
   end
 
   def long_polling_base_url

--- a/scripts/docker_manager_upgrade.rb
+++ b/scripts/docker_manager_upgrade.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+fork do
+  require_relative '../lib/docker_manager/upgrader.rb'
+
+  user_id = ENV['UPGRADE_USER_ID'].to_i
+  path = ENV['UPGRADE_PATH']
+  repo_version = ENV['UPGRADE_REPO_VERSION']
+  raise "user_id is required" if user_id <= 0
+  raise "path is required" if path.blank?
+
+  repo = DockerManager::AdminController.find_repos(path)
+  raise "No such repo" unless repo.present?
+
+  DockerManager::Upgrader.new(user_id, repo, repo_version).upgrade
+end

--- a/scripts/docker_manager_upgrade.rb
+++ b/scripts/docker_manager_upgrade.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+# we fork and let the parent die because we want the upgrade/child process
+# to be orphaned and adopted by the init process to prevent the upgrade
+# process from getting killed if/when unicorn gets killed.
 fork do
+  Process.setsid
   require_relative '../lib/docker_manager/upgrader.rb'
 
   user_id = ENV['UPGRADE_USER_ID'].to_i


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/start-upgrading-button-after-successfully-upgraded/162805?u=osama

Currently when admin starts an upgrade, an HTTP request is made to the server which then forks the unicorn worker that's handling the request and perform the upgrade in the forked process. This is problematic because unicorn workers have mini racer contexts which cause problems when they're forked, and this is the cause of the reported bug. This PR amends that so we no longer fork a unicorn worker and instead spawn a fresh/standalone process to perform the upgrade. This change may make upgrades eat more memory, but we'll keep an eye on it and if it becomes a problem we'll consider a different approach.

I've tested this change on an instance running on a DO droplet and have not seen any issues (and the reported bug is fixed).