### PR TITLE
Stop progress bar animation when upgrade is done

### DIFF
--- a/manager-client/app/templates/components/progress-bar.hbs
+++ b/manager-client/app/templates/components/progress-bar.hbs
@@ -1,1 +1,1 @@
-<div class="progress-bar progress-bar-striped progress-bar-animated" style={{barStyle}}></div>
+<div class="progress-bar progress-bar-striped {{#if active}}progress-bar-animated{{/if}}" style={{barStyle}}></div>


### PR DESCRIPTION
**Warning: This PR is untested and I don't know anything about Ember.**

A common problem I have when upgrading is that I am confused about the fact that the progress bar looks like it is doing something even though the process is actually finished. When removing the `progress-bar-animated` class after the process is done, it is a lot more clear what is going on. The component that specifies the `{{barStyle}}` variable also specifies `{{active}}` (see below), so my naive idea is to just check it in the template. If Ember does not work this way, I am sorry for the noise. Feel free to close this PR then :)

https://github.com/discourse/docker_manager/blob/13099552166edb6676cbc2188fb8decca2121331/manager-client/app/components/progress-bar.js#L7-L9