### PR TITLE
FEATURE: Prefer `origin/main` over `origin/master` if it exists

### DIFF
--- a/spec/lib/git_repo_spec.rb
+++ b/spec/lib/git_repo_spec.rb
@@ -22,4 +22,28 @@ RSpec.describe DockerManager::GitRepo do
     end
   end
 
+  describe "#branch" do
+
+    it "returns origin/master if a repo hasn't been renamed" do
+      described_class.any_instance.stubs(:upstream_branch).returns("origin/master")
+      described_class.any_instance.stubs(:has_origin_main?).returns(false)
+      repo = described_class.new("dummy", "dummy")
+      expect(repo.branch).to eq("origin/master")
+    end
+
+    it "returns origin/main if a repo has been renamed but still tracks master" do
+      described_class.any_instance.stubs(:upstream_branch).returns("origin/master")
+      described_class.any_instance.stubs(:has_origin_main?).returns(true)
+      repo = described_class.new("dummy", "dummy")
+      expect(repo.branch).to eq("origin/main")
+    end
+
+    it "returns origin/main if a repo points at origin/main" do
+      described_class.any_instance.stubs(:upstream_branch).returns("origin/main")
+      described_class.any_instance.stubs(:has_origin_main?).returns(true)
+      repo = described_class.new("dummy", "dummy")
+      expect(repo.branch).to eq("origin/main")
+    end
+
+  end
 end


### PR DESCRIPTION
This allows us to rename the main branch for plugin repos to
`origin/main` and docker_manager should continue to work.