### PR TITLE
FEATURE: When upgrading, if `origin/main` exists switch to that branch

### DIFF
--- a/lib/docker_manager/git_repo.rb
+++ b/lib/docker_manager/git_repo.rb
@@ -91,6 +91,14 @@ class DockerManager::GitRepo
     find_all.detect { |r| r.path == path }
   end
 
+  def upstream_branch
+    @upstream_branch ||= run("for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)")
+  end
+
+  def has_local_main?
+    run("show-ref refs/heads/main").present?
+  end
+
   protected
 
   def prettify_tag_version(command)
@@ -110,10 +118,6 @@ class DockerManager::GitRepo
   def commit_date(commit)
     unix_timestamp = run(+'show -s --format="%ct" ' << commit).to_i
     Time.at(unix_timestamp).to_datetime
-  end
-
-  def upstream_branch
-    run("for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)")
   end
 
   def has_origin_main?

--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -68,7 +68,24 @@ class DockerManager::Upgrader
     # HEAD@{upstream} is just a fancy way how to say origin/master (in normal case)
     # see http://stackoverflow.com/a/12699604/84283
     @repos.each_with_index do |repo, index|
-      run("cd #{repo.path} && git fetch --tags --force && git reset --hard HEAD@{upstream}")
+
+      # We automatically handle renames from `master` -> `main`
+      if repo.upstream_branch == "origin/master" && repo.branch == "origin/main"
+        log "Branch has changed to #{repo.branch}"
+
+        # Just in case `main` exists locally but is not used. Perhaps it was fetched?
+        if repo.has_local_main?
+          run "cd #{repo.path} && git checkout main"
+        else
+          run "cd #{repo.path} && git branch -m master main"
+        end
+
+        run "cd #{repo.path} && git fetch origin --tags --force"
+        run "cd #{repo.path} && git branch -u origin/main main"
+      else
+        run("cd #{repo.path} && git fetch --tags --force && git reset --hard HEAD@{upstream}")
+      end
+
       percent(20 * (index + 1) / @repos.size)
     end
 


### PR DESCRIPTION
This involves checking out/renaming a local branch, then fetching, then
updating the upstream.

This allows plugins to automatically update to `origin/main` when
present.