### PR TITLE
FIX: Support origin/main again

### DIFF
--- a/lib/docker_manager/git_repo.rb
+++ b/lib/docker_manager/git_repo.rb
@@ -91,6 +91,14 @@ class DockerManager::GitRepo
     find_all.detect { |r| r.path == path }
   end
 
+  def upstream_branch
+    @upstream_branch ||= run("for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)")
+  end
+
+  def has_local_main?
+    run("show-ref refs/heads/main").present?
+  end
+
   protected
 
   def prettify_tag_version(command)
@@ -110,10 +118,6 @@ class DockerManager::GitRepo
   def commit_date(commit)
     unix_timestamp = run(+'show -s --format="%ct" ' << commit).to_i
     Time.at(unix_timestamp).to_datetime
-  end
-
-  def upstream_branch
-    run("for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)")
   end
 
   def has_origin_main?

--- a/lib/docker_manager/git_repo.rb
+++ b/lib/docker_manager/git_repo.rb
@@ -121,7 +121,7 @@ class DockerManager::GitRepo
   end
 
   def has_origin_main?
-    run("branch -r").include?("origin/main") rescue false
+    run("branch -a").match?(/remotes\/origin\/main$/) rescue false
   end
 
   def tracking_branch


### PR DESCRIPTION
We reverted due to errors if a remote branch started with `origin/main`.

Now it will correctly identify the remote branch regardless.