### PR TITLE
UX: Always show the docker_manager plugin second in the list

### DIFF
--- a/lib/docker_manager/git_repo.rb
+++ b/lib/docker_manager/git_repo.rb
@@ -74,8 +74,12 @@ class DockerManager::GitRepo
   end
 
   def self.find_all
-    repos = [DockerManager::GitRepo.new(Rails.root.to_s, 'discourse')]
+    repos = [
+      DockerManager::GitRepo.new(Rails.root.to_s, 'discourse'),
+      DockerManager::GitRepo.new("#{Rails.root}/plugins/docker_manager", "docker_manager")
+    ]
     p = Proc.new { |x|
+      next if x.name == "docker_manager"
       repos << DockerManager::GitRepo.new(File.dirname(x.path), x.name)
     }
     if Discourse.respond_to?(:visible_plugins)


### PR DESCRIPTION
docker_manager must have its version checked before any other actions can be taken. Having it higher in the list makes this process much quicker for admins.