### PR TITLE
allow proxy env vars

### DIFF
--- a/app/controllers/docker_manager/admin_controller.rb
+++ b/app/controllers/docker_manager/admin_controller.rb
@@ -91,13 +91,17 @@ module DockerManager
       raise Discourse::NotFound unless repo.present?
       script_path = File.expand_path(File.join(__dir__, '../../../scripts/docker_manager_upgrade.rb'))
 
-      pid = spawn(
-        {
+      env_vars = {
           'UPGRADE_USER_ID' => current_user.id.to_s,
           'UPGRADE_PATH' => params[:path].to_s,
           'UPGRADE_REPO_VERSION' => repo_version(repo).to_s,
           'RAILS_ENV' => Rails.env
-        },
+      }
+      ["http_proxy","https_proxy","no_proxy","HTTP_PROXY","HTTPS_PROXY","NO_PROXY"].each do |p|
+        env_vars[p] = ENV[p] if ! ENV[p].nil?
+      end
+      pid = spawn(
+        env_vars,
         "bundle exec rails runner #{script_path}"
       )
       Process.detach(pid)

--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -168,6 +168,12 @@ class DockerManager::Upgrader
       PATH
       COMPRESS_BROTLI
       FORCE_S3_UPLOADS
+      HTTP_PROXY
+      HTTPS_PROXY
+      NO_PROXY
+      http_proxy
+      https_proxy
+      no_proxy
     }
 
     clear_env = Hash[*ENV.map { |k, v| [k, nil] }


### PR DESCRIPTION
Hi,
I added in a few lines to pass-through already set HTTP proxy environment variables.
This enabled docker_manager to perform the update for new versions of discourse and plugins on our server (which otherwise has outgoing internet blocked).  Funnily enough the check for updates was working okay (presumably this occurs with the env vars that are set in app.yml).
Hope this is good enough to incorporate or adapt.
Thanks, Ben