### PR TITLE
FIX: Run `yarn install` during updates

### DIFF
--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -91,6 +91,7 @@ class DockerManager::Upgrader
     end
 
     run("bundle install --deployment --jobs 4 --without test development")
+    run("yarn install --production")
     begin
       run("LOAD_PLUGINS=0 bundle exec rake plugin:pull_compatible_all")
     rescue RuntimeError


### PR DESCRIPTION
This is required to compile assets successfully under Ember CLI