### PR TITLE
DEV: Bump base image and expected ruby version

### DIFF
--- a/app/controllers/docker_manager/admin_controller.rb
+++ b/app/controllers/docker_manager/admin_controller.rb
@@ -13,9 +13,9 @@ module DockerManager
       version = File.read('/VERSION') rescue '1.0.0'
 
       version = Gem::Version.new(version)
-      expected_version = Gem::Version.new('2.0.20211118-0105')
+      expected_version = Gem::Version.new('2.0.20220128-1817')
       ruby_version = Gem::Version.new(RUBY_VERSION)
-      expected_ruby_version = Gem::Version.new('2.7.2')
+      expected_ruby_version = Gem::Version.new('2.7.5')
 
       if (version < expected_version) || (ruby_version < expected_ruby_version)
         render 'upgrade_required', layout: false


### PR DESCRIPTION
The new base image includes the following:
* Fix for CVE-2021-4034 (PwnKit) - local privilege escalation vulnerability with `pkexec`
* Ruby upgraded to 2.7.5p203
* Installing `pups` via gem