### PR TITLE
DEV: Remove ie 11 from build targets

### DIFF
--- a/manager-client/config/targets.js
+++ b/manager-client/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers
 };


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_3-0-browser-support-policy