### PR TITLE
DEV: Remove use of assign polyfill

### DIFF
--- a/manager-client/tests/helpers/start-app.js
+++ b/manager-client/tests/helpers/start-app.js
@@ -1,13 +1,12 @@
 import Application from "../../app";
 import config from "../../config/environment";
-import { assign } from "@ember/polyfills";
 import { run } from "@ember/runloop";
 
 export default function startApp(attrs) {
   let application;
 
   // use defaults, but you can override
-  let attributes = assign({}, config.APP, attrs);
+  let attributes = Object.assign({}, config.APP, attrs);
 
   run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign