### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/manager-client/app/components/progress-bar.js
+++ b/manager-client/app/components/progress-bar.js
@@ -1,22 +1,23 @@
 import Component from "@ember/component";
 import { computed } from "@ember/object";
+import { htmlSafe } from "@ember/template";
 
 export default Component.extend({
   classNameBindings: [":progress", ":progress-striped", "active"],
 
-  active: computed("percent", function() {
+  active: computed("percent", function () {
     return parseInt(this.get("percent"), 10) !== 100;
   }),
 
-  barStyle: computed("percent", function() {
+  barStyle: computed("percent", function () {
     let percent = parseInt(this.get("percent"), 10);
     if (percent > 0) {
       if (percent > 100) {
         percent = 100;
       }
-      return ("width: " + this.get("percent") + "%").htmlSafe();
+      return htmlSafe("width: " + this.get("percent") + "%");
     }
 
-    return "".htmlSafe();
-  })
+    return htmlSafe("");
+  }),
 });


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions