### PR TITLE
FIX: Incorrect use of d-icon params

### DIFF
--- a/admin/assets/javascripts/discourse/components/docker-manager/repo-status.hbs
+++ b/admin/assets/javascripts/discourse/components/docker-manager/repo-status.hbs
@@ -4,8 +4,7 @@
       {{d-icon
         this.officialRepoBadge
         class="check-circle"
-        alt=this.officialRepoBadgeTitle
-        title=this.officialRepoBadgeTitle
+        translatedTitle=this.officialRepoBadgeTitle
       }}
     {{/if}}
   </td>


### PR DESCRIPTION
It doesn't support alt and the title was already a translated string.