### PR TITLE
FIX: Remove ruby memory flags

### DIFF
--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -103,17 +103,13 @@ class DockerManager::Upgrader
     run("SKIP_POST_DEPLOYMENT_MIGRATIONS=1 bundle exec rake multisite:migrate")
     percent(40)
     log("*** Bundling assets. This will take a while *** ")
-    less_memory_flags =
-      "RUBY_GC_MALLOC_LIMIT_MAX=20971520 RUBY_GC_OLDMALLOC_LIMIT_MAX=20971520 RUBY_GC_HEAP_GROWTH_MAX_SLOTS=50000 RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0.9 "
-    run("#{less_memory_flags} bundle exec rake themes:update assets:precompile")
+    run("bundle exec rake themes:update assets:precompile")
 
     using_s3_assets =
       ENV["DISCOURSE_USE_S3"] && ENV["DISCOURSE_S3_BUCKET"] &&
         ENV["DISCOURSE_S3_CDN_URL"]
 
-    if using_s3_assets
-      run("#{less_memory_flags} bundle exec rake s3:upload_assets")
-    end
+    run("bundle exec rake s3:upload_assets") if using_s3_assets
 
     percent(80)
     reload_unicorn(launcher_pid)
@@ -131,9 +127,7 @@ class DockerManager::Upgrader
     log("Running post deploy migrations")
     run("bundle exec rake multisite:migrate")
 
-    if using_s3_assets
-      run("#{less_memory_flags} bundle exec rake s3:expire_missing_assets")
-    end
+    run("bundle exec rake s3:expire_missing_assets") if using_s3_assets
 
     log_version_upgrade
     percent(100)


### PR DESCRIPTION
These seem to be hurting performance in the latest version of Ruby