### PR TITLE
DEV: Only show upgrade tab for admins

### DIFF
--- a/admin/assets/javascripts/discourse/templates/connectors/admin-menu/upgrade-link.hbs
+++ b/admin/assets/javascripts/discourse/templates/connectors/admin-menu/upgrade-link.hbs
@@ -1,1 +1,3 @@
-<NavItem @route="upgrade" @label="admin.docker.upgrade_tab" />
+{{#if this.currentUser.admin}}
+  <NavItem @route="upgrade" @label="admin.docker.upgrade_tab" />
+{{/if}}


### PR DESCRIPTION
### Background

[Meta](https://meta.discourse.org/t/upgrade-tab-visible-for-moderators/258499).

In #167 we added an "Upgrade" tab to the admin menu, but it's also showing for moderators, even though they can't access it, leading to "Oops! That page doesn’t exist or is private."

### What is this change

Simply hide the upgrade tab for non-admin users.