### PR TITLE
FEATURE: Adds support for git tags

### DIFF
--- a/admin/assets/javascripts/discourse/routes/upgrade.js
+++ b/admin/assets/javascripts/discourse/routes/upgrade.js
@@ -25,7 +25,11 @@ export default class Upgrade extends Route {
 
     if (discourse?.branch === "origin/main") {
       // Special case: If the branch is "main" warn user
-      controller.appendBannerHtml(I18n.t("admin.docker.main_branch_warning"));
+      controller.appendBannerHtml(
+        I18n.t("admin.docker.main_branch_warning", {
+          url: "https://meta.discourse.org/t/17014",
+        })
+      );
     }
   }
 

--- a/app/controllers/docker_manager/admin_controller.rb
+++ b/app/controllers/docker_manager/admin_controller.rb
@@ -10,11 +10,13 @@ module DockerManager
 
     def repos
       repos = DockerManager::GitRepo.find_all
+      core_repo = repos.find { |r| r.name == "discourse" }
+
       repos.map! do |r|
         result = {
           name: r.name,
           path: r.path,
-          branch: r.branch,
+          branch: r.tracking_ref,
           official: Plugin::Metadata::OFFICIAL_PLUGINS.include?(r.name),
         }
 
@@ -54,7 +56,8 @@ module DockerManager
         upgrade_ruby = ruby_version < expected_ruby_version
         upgrade_discourse = discourse_upgrade_required?(min_stable_version, min_beta_version)
 
-        response[:upgrade_required] = true if upgrade_image || upgrade_ruby || upgrade_discourse
+        response[:upgrade_required] = true if upgrade_image || upgrade_ruby || upgrade_discourse ||
+          !core_repo.upstream_branch_exist?
       end
 
       render json: response

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -11,7 +11,7 @@ en:
         forked_plugin: "Forked Official Plugin"
         last_updated: "Last Updated:"
         latest_version: "Latest Version:"
-        main_branch_warning: "<b>WARNING:</b> Your Discourse is tracking the 'main' branch which may be unstable, <a href='https://meta.discourse.org/t/change-tracking-branch-for-your-discourse-instance/17014'> we recommend tracking the 'tests-passed' branch</a>."
+        main_branch_warning: "<b>WARNING:</b> Your Discourse is tracking the 'main' branch which may be unstable, <a href='%{url}'> we recommend tracking the 'tests-passed' branch</a>."
         navigation:
           processes: Processes
           versions: Versions

--- a/lib/docker_manager/git_repo.rb
+++ b/lib/docker_manager/git_repo.rb
@@ -1,14 +1,31 @@
 # frozen_string_literal: true
 
-# like Grit just very very minimal
 class DockerManager::GitRepo
-  attr_reader :path, :name, :branch
+  attr_reader :path, :name
+
+  def self.find_all
+    repos = [
+      DockerManager::GitRepo.new(Rails.root.to_s, "discourse"),
+      DockerManager::GitRepo.new("#{Rails.root}/plugins/docker_manager", "docker_manager"),
+    ]
+
+    Discourse.visible_plugins.each do |p|
+      next if p.name == "docker_manager"
+      repo = DockerManager::GitRepo.new(File.dirname(p.path), p.name)
+      repos << repo if repo.valid?
+    end
+
+    repos
+  end
+
+  def self.find(path)
+    find_all.detect { |r| r.path == path }
+  end
 
   def initialize(path, name = nil)
     @path = path
     @name = name
     @memoize = {}
-    @branch = tracking_branch
   end
 
   def start_upgrading
@@ -36,76 +53,80 @@ class DockerManager::GitRepo
   end
 
   def latest_origin_commit
-    run "rev-parse #{tracking_branch}"
+    run "rev-parse #{tracking_ref}^{}"
   end
 
   def latest_local_tag_version
-    prettify_tag_version("describe HEAD 2>/dev/null")
+    prettify_tag_version("describe --exclude 'beta' HEAD 2>/dev/null")
   end
 
   def latest_origin_tag_version
-    prettify_tag_version("describe #{tracking_branch} 2>/dev/null")
-  end
-
-  def latest_origin_commit_date
-    commit_date(latest_origin_commit)
+    prettify_tag_version(
+      "describe --exclude 'beta' --exclude 'latest-release' #{tracking_ref} 2>/dev/null",
+    )
   end
 
   def latest_local_commit_date
     commit_date(latest_local_commit)
   end
 
+  def latest_origin_commit_date
+    commit_date(latest_origin_commit)
+  end
+
   def commits_behind
-    run("rev-list --count HEAD..#{tracking_branch}").to_i
+    run("rev-list --count HEAD..#{tracking_ref}").to_i
   end
 
   def url
-    url = run "config --get remote.origin.url"
-    if url =~ /^git/
-      # hack so it works with git urls
-      url = "https://github.com/#{url.split(":")[1]}"
-    end
-
+    url = run("config --get remote.origin.url")
+    url = "https://github.com/#{url}" if url&.delete_prefix!("git@github.com:")
     url
   end
 
   def update_remote!
-    `cd #{path} && git remote update`
-  end
-
-  def self.find_all
-    repos = [
-      DockerManager::GitRepo.new(Rails.root.to_s, "discourse"),
-      DockerManager::GitRepo.new("#{Rails.root}/plugins/docker_manager", "docker_manager"),
-    ]
-
-    Discourse.visible_plugins.each do |p|
-      next if p.name == "docker_manager"
-      repo = DockerManager::GitRepo.new(File.dirname(p.path), p.name)
-      repos << repo if repo.valid?
+    if shallow_clone?
+      git("fetch --depth=1 origin")
+    else
+      git("fetch --tags --prune --prune-tags --force origin")
     end
-
-    repos
-  end
-
-  def self.find(path)
-    find_all.detect { |r| r.path == path }
-  end
-
-  def upstream_branch
-    @upstream_branch ||=
-      run("for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)")
   end
 
   def has_local_main?
     run("show-ref refs/heads/main").present?
   end
 
+  def tracking_ref
+    tracking_branch.presence || tracking_tag
+  end
+
+  def upstream_branch
+    head_ref = run("symbolic-ref -q HEAD")
+    return if head_ref.blank?
+    run("for-each-ref --format='%(upstream:short)' #{head_ref}")
+  end
+
+  def upstream_branch_exist?
+    branch_name = upstream_branch
+    return false if branch_name.blank?
+
+    if shallow_clone?
+      branch_name = branch_name.delete_prefix("origin/")
+      run("ls-remote --heads origin #{branch_name}").present?
+    else
+      run("show-branch remotes/#{branch_name}").include?(branch_name)
+    end
+  end
+
   protected
+
+  def shallow_clone?
+    run("rev-parse --is-shallow-repository") == "true"
+  end
 
   def prettify_tag_version(command)
     result = run(command)
-    return unless result.present?
+    return if result.blank?
 
     result = result.gsub(/-(\d+)-.*/, " +#{$1}") if result =~ /-(\d+)-/
     result
@@ -116,16 +137,12 @@ class DockerManager::GitRepo
   end
 
   def commit_date(commit)
-    unix_timestamp = run(+'show -s --format="%ct" ' << commit).to_i
+    unix_timestamp = run("show -s --format='%ct' #{commit}").to_i
     Time.at(unix_timestamp).to_datetime
   end
 
   def has_origin_main?
-    begin
-      run("branch -a").match?(%r{remotes/origin/main$})
-    rescue StandardError
-      false
-    end
+    run("branch -a")&.match?(%r{remotes/origin/main$})
   end
 
   def tracking_branch
@@ -142,9 +159,17 @@ class DockerManager::GitRepo
     head
   end
 
+  def tracking_tag
+    run("config user.discourse-version")
+  end
+
   def run(cmd)
-    @memoize[cmd] ||= `cd #{path} && git #{cmd}`.strip
+    @memoize[cmd] ||= git(cmd)
   rescue => e
     puts e.inspect
+  end
+
+  def git(cmd)
+    `cd #{path} && git #{cmd}`.strip
   end
 end

--- a/spec/lib/git_repo_spec.rb
+++ b/spec/lib/git_repo_spec.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 require "docker_manager/git_repo"
+require_relative "../support/git_helpers"
 
 RSpec.describe DockerManager::GitRepo do
   describe ".find_all" do
+    subject { described_class.find_all }
+
     it "returns a list of repos" do
-      expect(described_class.find_all).to be_present
+      expect(subject).to be_present
+    end
+
+    it "contains the `docker_manager` and `discourse` repos" do
+      expect(subject.map(&:name)).to include("discourse", "docker_manager")
     end
   end
 
@@ -20,29 +27,528 @@ RSpec.describe DockerManager::GitRepo do
     end
   end
 
-  describe "#branch" do
-    it "returns origin/master if a repo hasn't been renamed" do
-      described_class.any_instance.stubs(:upstream_branch).returns("origin/master")
-      described_class.any_instance.stubs(:has_origin_main?).returns(false)
-      repo = described_class.new("dummy", "dummy")
-
-      expect(repo.branch).to eq("origin/master")
+  context "with git repo" do
+    def shallow_clone?
+      clone_method == GitHelpers::CLONE_SHALLOW
     end
 
-    it "returns origin/main if a repo has been renamed but still tracks master" do
-      described_class.any_instance.stubs(:upstream_branch).returns("origin/master")
-      described_class.any_instance.stubs(:has_origin_main?).returns(true)
-      repo = described_class.new("dummy", "dummy")
-
-      expect(repo.branch).to eq("origin/main")
+    def skip_for_shallow_clone
+      pending("Doesn't work on shallow clones") if shallow_clone?
     end
 
-    it "returns origin/main if a repo points at origin/main" do
-      described_class.any_instance.stubs(:upstream_branch).returns("origin/main")
-      described_class.any_instance.stubs(:has_origin_main?).returns(true)
-      repo = described_class.new("dummy", "dummy")
+    let!(:initial_branch) { "main" }
 
-      expect(repo.branch).to eq("origin/main")
+    before do
+      @skip_update_remote = false
+      @local_repo = @remote_git_repo = nil
+      @before_local_repo_clone = []
+      @after_local_repo_clone = []
     end
+    after { @remote_git_repo.destroy }
+
+    def prepare_repos
+      return if @local_repo && @remote_git_repo
+
+      @remote_git_repo = GitHelpers::RemoteGitRepo.new(initial_branch: initial_branch)
+      @remote_git_repo.commit(
+        filename: "foo.txt",
+        commits: [
+          { content: "A", date: "2023-03-06T20:31:17Z" },
+          {
+            content: "B",
+            date: "2023-03-06T21:08:52Z",
+            tags: %w[v3.1.0.beta1 beta latest-release],
+          },
+          { content: "C", date: "2023-03-06T22:48:29Z" },
+        ],
+      )
+      @remote_git_repo.create_branches("tests-passed")
+
+      @before_local_repo_clone.each { |callback| callback.call }
+      @local_repo = @remote_git_repo.create_local_clone(method: clone_method)
+      @after_local_repo_clone.each { |callback| callback.call }
+
+      @remote_git_repo.in_remote_repo { |git| git.call("log --pretty=oneline") }
+    end
+
+    subject do
+      prepare_repos
+      repo = described_class.new(@local_repo.path)
+      repo.update_remote! unless @skip_update_remote
+      repo
+    end
+
+    def add_new_commits
+      @remote_git_repo.commit(
+        filename: "foo.txt",
+        commits: [
+          { content: "D", date: "2023-03-07T10:11:19Z" },
+          {
+            content: "E",
+            date: "2023-03-07T12:58:29Z",
+            tags: %w[v3.1.0.beta2 beta latest-release],
+          },
+          { content: "F", date: "2023-03-07T15:22:23Z" },
+        ],
+      )
+      @remote_git_repo.rebase(source_branch: "main", target_branch: "tests-passed")
+    end
+
+    shared_examples "common tests" do
+      context "when tracking `tests-passed` branch" do
+        before { @after_local_repo_clone << -> { @local_repo.checkout("tests-passed") } }
+
+        describe "#has_local_main?" do
+          context "with existing `main` branch" do
+            let(:initial_branch) { "main" }
+
+            it "detects the branch" do
+              expect(subject.has_local_main?).to eq(true)
+            end
+          end
+
+          context "with missing `main` branch" do
+            let(:initial_branch) { "master" }
+
+            it "doesn't detect the branch" do
+              expect(subject.has_local_main?).to eq(false)
+            end
+          end
+        end
+
+        describe "#tracking_ref" do
+          it "returns the correct remote branch" do
+            expect(subject.tracking_ref).to eq("origin/tests-passed")
+          end
+
+          context "with `master` as initial branch" do
+            let(:initial_branch) { "master" }
+
+            before { @after_local_repo_clone << -> { @local_repo.checkout("master") } }
+
+            it "returns `origin/master` if a repo hasn't been renamed" do
+              expect(subject.tracking_ref).to eq("origin/master")
+            end
+
+            it "returns `origin/main` if a repo has been renamed but still tracks `master`" do
+              @after_local_repo_clone << -> {
+                @remote_git_repo.rename_branch(old_name: "master", new_name: "main")
+              }
+
+              expect(subject.tracking_ref).to eq("origin/main")
+            end
+          end
+
+          context "with `main` as current local branch" do
+            before { @after_local_repo_clone << -> { @local_repo.checkout("main") } }
+
+            it "returns `origin/main` if a repo points at `origin/main`" do
+              expect(subject.tracking_ref).to eq("origin/main")
+            end
+          end
+        end
+
+        describe "#upstream_branch" do
+          it "returns the correct branch name" do
+            expect(subject.upstream_branch).to eq("origin/tests-passed")
+          end
+        end
+
+        describe "#upstream_branch_exist?" do
+          it "returns true when upstream branch exist" do
+            expect(subject.upstream_branch_exist?).to eq(true)
+          end
+
+          it "returns false when upstream branch doesn't exist" do
+            @after_local_repo_clone << -> { @remote_git_repo.delete_branches("tests-passed") }
+            expect(subject.upstream_branch_exist?).to eq(false)
+          end
+        end
+
+        context "when local clone and origin are the same" do
+          describe "#latest_local_commit" do
+            it "returns the correct commit hash" do
+              expect(subject.latest_local_commit).to eq("16a1d8111ff1eb6e8fc1d1b973b4fd92cacbebcc")
+            end
+          end
+
+          describe "#latest_origin_commit" do
+            it "returns the correct commit hash" do
+              expect(subject.latest_origin_commit).to eq("16a1d8111ff1eb6e8fc1d1b973b4fd92cacbebcc")
+            end
+          end
+
+          describe "#latest_local_commit_date" do
+            it "returns the correct commit date" do
+              expect(subject.latest_local_commit_date).to eq("2023-03-06T22:48:29Z")
+            end
+          end
+
+          describe "#latest_origin_commit_date" do
+            it "returns the correct commit date" do
+              expect(subject.latest_origin_commit_date).to eq("2023-03-06T22:48:29Z")
+            end
+          end
+
+          context "with no tags" do
+            before do
+              @before_local_repo_clone << -> {
+                @remote_git_repo.delete_tags("beta", "latest-release", "v3.1.0.beta1")
+              }
+            end
+
+            describe "#latest_local_tag_version" do
+              it "returns nil as version" do
+                expect(subject.latest_local_tag_version).to be_nil
+              end
+            end
+
+            describe "#latest_origin_tag_version" do
+              it "returns nil as version" do
+                expect(subject.latest_origin_tag_version).to be_nil
+              end
+            end
+          end
+
+          context "with `beta`, `latest-release` and version tags on HEAD~1" do
+            before { skip_for_shallow_clone }
+
+            describe "#latest_local_tag_version" do
+              it "returns the correct version and ignores the `beta` tag" do
+                expect(subject.latest_local_tag_version).to eq("latest-release +1")
+              end
+            end
+
+            describe "#latest_origin_tag_version" do
+              it "returns the correct version and ignores the `beta` and `latest-release` tags" do
+                expect(subject.latest_origin_tag_version).to eq("v3.1.0.beta1 +1")
+              end
+            end
+          end
+
+          context "with `beta` and version tags on HEAD~1" do
+            before do
+              skip_for_shallow_clone
+              @before_local_repo_clone << -> { @remote_git_repo.delete_tags("latest-release") }
+            end
+
+            describe "#latest_local_tag_version" do
+              it "returns the correct version and ignores the `beta` tag" do
+                expect(subject.latest_local_tag_version).to eq("v3.1.0.beta1 +1")
+              end
+            end
+
+            describe "#latest_origin_tag_version" do
+              it "returns the correct version and ignores the `beta` tag" do
+                expect(subject.latest_origin_tag_version).to eq("v3.1.0.beta1 +1")
+              end
+            end
+          end
+
+          describe "#commits_behind" do
+            it "returns 0 because local and origin are the same" do
+              expect(subject.commits_behind).to eq(0)
+            end
+          end
+
+          describe "#update_remote!" do
+            it "fetches the correct amount of new commits" do
+              prepare_repos
+              expect { subject.update_remote! }.to not_change { @local_repo.commit_count }
+            end
+          end
+        end
+
+        context "when origin has new commits" do
+          before { @after_local_repo_clone << method(:add_new_commits) }
+
+          describe "#latest_local_commit" do
+            it "returns the correct commit hash" do
+              expect(subject.latest_local_commit).to eq("16a1d8111ff1eb6e8fc1d1b973b4fd92cacbebcc")
+            end
+          end
+
+          describe "#latest_origin_commit" do
+            it "returns the correct commit hash" do
+              expect(subject.latest_origin_commit).to eq("44b4ef6472e902d767335c4b19d47fd7a079d7c3")
+            end
+          end
+
+          describe "#latest_local_commit_date" do
+            it "returns the correct commit date" do
+              expect(subject.latest_local_commit_date).to eq("2023-03-06T22:48:29Z")
+            end
+          end
+
+          describe "#latest_origin_commit_date" do
+            it "returns the correct commit date" do
+              expect(subject.latest_origin_commit_date).to eq("2023-03-07T15:22:23Z")
+            end
+          end
+
+          describe "#latest_local_tag_version" do
+            it "returns the correct version" do
+              skip_for_shallow_clone
+              expect(subject.latest_local_tag_version).to eq("v3.1.0.beta1 +1")
+            end
+          end
+
+          describe "#latest_origin_tag_version" do
+            it "returns the correct version and ignores the `beta` and `latest-release` tags" do
+              skip_for_shallow_clone
+              expect(subject.latest_origin_tag_version).to eq("v3.1.0.beta2 +1")
+            end
+          end
+
+          describe "#commits_behind" do
+            it "returns the correct number of commits" do
+              skip_for_shallow_clone
+              expect(subject.commits_behind).to eq(3)
+            end
+          end
+
+          describe "#update_remote!" do
+            it "fetches the correct amount of new commits" do
+              prepare_repos
+              expect { subject.update_remote! }.to change { @local_repo.commit_count }.by(
+                fetch_commit_count,
+              )
+            end
+          end
+        end
+      end
+
+      context "when tracking `beta` tag" do
+        before do
+          @after_local_repo_clone << -> {
+            unless shallow_clone?
+              @local_repo.checkout("beta")
+              # Mimics the behavior of `web.template.yml` where we store the value of the `$version` variable
+              # as a user-defined config value in git.
+              # See https://github.com/discourse/discourse_docker/blob/main/templates/web.template.yml
+              @local_repo.git("config user.discourse-version beta")
+            end
+          }
+        end
+
+        describe "#has_local_main?" do
+          context "with existing `main` branch" do
+            let(:initial_branch) { "main" }
+
+            it "detects the branch" do
+              expect(subject.has_local_main?).to eq(true)
+            end
+          end
+
+          context "with missing `main` branch" do
+            let(:initial_branch) { "master" }
+
+            it "doesn't detect the branch" do
+              expect(subject.has_local_main?).to eq(false)
+            end
+          end
+        end
+
+        describe "#tracking_ref" do
+          it "returns the correct remote branch" do
+            skip_for_shallow_clone
+            expect(subject.tracking_ref).to eq("beta")
+          end
+        end
+
+        describe "#upstream_branch" do
+          it "doesn't return a branch name" do
+            skip_for_shallow_clone
+            expect(subject.upstream_branch).to be_nil
+          end
+        end
+
+        describe "#upstream_branch_exist?" do
+          it "returns false because we aren't tracking a branch" do
+            skip_for_shallow_clone
+            expect(subject.upstream_branch_exist?).to eq(false)
+          end
+        end
+
+        context "when local clone and origin are the same" do
+          describe "#latest_local_commit" do
+            it "returns the correct commit hash" do
+              skip_for_shallow_clone
+              expect(subject.latest_local_commit).to eq("e43b6978c22ea3aeafbcf96c6e4fff5af0b7da29")
+            end
+          end
+
+          describe "#latest_origin_commit" do
+            it "returns the correct commit hash" do
+              skip_for_shallow_clone
+              expect(subject.latest_origin_commit).to eq("e43b6978c22ea3aeafbcf96c6e4fff5af0b7da29")
+            end
+          end
+
+          describe "#latest_local_commit_date" do
+            it "returns the correct commit date" do
+              skip_for_shallow_clone
+              expect(subject.latest_local_commit_date).to eq("2023-03-06T21:08:52Z")
+            end
+          end
+
+          describe "#latest_origin_commit_date" do
+            it "returns the correct commit date" do
+              skip_for_shallow_clone
+              expect(subject.latest_origin_commit_date).to eq("2023-03-06T21:08:52Z")
+            end
+          end
+
+          describe "#latest_local_tag_version" do
+            it "returns the correct version and ignores the `beta` tag" do
+              skip_for_shallow_clone
+              expect(subject.latest_local_tag_version).to eq("latest-release")
+            end
+          end
+
+          describe "#latest_origin_tag_version" do
+            it "returns the correct version and ignores the `beta` and `latest-release` tags" do
+              skip_for_shallow_clone
+              expect(subject.latest_origin_tag_version).to eq("v3.1.0.beta1")
+            end
+          end
+
+          describe "#commits_behind" do
+            it "returns 0 because local and origin are the same" do
+              expect(subject.commits_behind).to eq(0)
+            end
+          end
+
+          describe "#update_remote!" do
+            it "fetches the correct amount of new commits" do
+              prepare_repos
+              expect { subject.update_remote! }.to not_change { @local_repo.commit_count }
+            end
+          end
+        end
+
+        context "when origin has new commits" do
+          before { @after_local_repo_clone << method(:add_new_commits) }
+
+          describe "#latest_local_commit" do
+            it "returns the correct commit hash" do
+              skip_for_shallow_clone
+              expect(subject.latest_local_commit).to eq("e43b6978c22ea3aeafbcf96c6e4fff5af0b7da29")
+            end
+          end
+
+          describe "#latest_origin_commit" do
+            it "returns the correct commit hash" do
+              skip_for_shallow_clone
+              expect(subject.latest_origin_commit).to eq("bebd76be58db951fac6abc8d4d0746951fcd1082")
+            end
+          end
+
+          describe "#latest_local_commit_date" do
+            it "returns the correct commit date" do
+              skip_for_shallow_clone
+              expect(subject.latest_local_commit_date).to eq("2023-03-06T21:08:52Z")
+            end
+          end
+
+          describe "#latest_origin_commit_date" do
+            it "returns the correct commit date" do
+              skip_for_shallow_clone
+              expect(subject.latest_origin_commit_date).to eq("2023-03-07T12:58:29Z")
+            end
+          end
+
+          describe "#latest_local_tag_version" do
+            it "returns the correct version" do
+              skip_for_shallow_clone
+              expect(subject.latest_local_tag_version).to eq("v3.1.0.beta1")
+            end
+          end
+
+          describe "#latest_origin_tag_version" do
+            it "returns the correct version" do
+              skip_for_shallow_clone
+              expect(subject.latest_origin_tag_version).to eq("v3.1.0.beta2")
+            end
+          end
+
+          describe "#commits_behind" do
+            it "returns the correct number of commits" do
+              skip_for_shallow_clone
+              expect(subject.commits_behind).to eq(3)
+            end
+          end
+
+          describe "#update_remote!" do
+            it "fetches the correct amount of new commits" do
+              prepare_repos
+              expect { subject.update_remote! }.to change { @local_repo.commit_count }.by(
+                fetch_commit_count,
+              )
+            end
+          end
+        end
+      end
+
+      describe "#url" do
+        before do
+          @skip_update_remote = true
+          @after_local_repo_clone << -> { @local_repo.git("remote set-url origin #{remote_url}") }
+        end
+
+        context "with GitHub HTTPS URL" do
+          let(:remote_url) { "https://github.com/discourse/example.git" }
+
+          it "returns the unmodified URL" do
+            expect(subject.url).to eq("https://github.com/discourse/example.git")
+          end
+        end
+
+        context "with GitHub SSH URL" do
+          let(:remote_url) { "git@github.com:discourse/example.git" }
+
+          it "returns a HTTPS URL" do
+            expect(subject.url).to eq("https://github.com/discourse/example.git")
+          end
+        end
+
+        context "with a different HTTPS URL" do
+          let(:remote_url) { "https://example.com/discourse.git" }
+
+          it "returns the unmodified URL" do
+            expect(subject.url).to eq("https://example.com/discourse.git")
+          end
+        end
+
+        context "with a different SSH URL" do
+          let(:remote_url) { "git@example.com:discourse.git" }
+
+          it "returns the unmodified URL" do
+            expect(subject.url).to eq("git@example.com:discourse.git")
+          end
+        end
+      end
+    end
+
+    context "with full clone" do
+      let!(:clone_method) { GitHelpers::CLONE_FULL }
+      let(:fetch_commit_count) { 3 }
+
+      include_examples "common tests"
+    end
+
+    # context "with shallow clone" do
+    #   let!(:clone_method) { GitHelpers::CLONE_SHALLOW }
+    #   let(:fetch_commit_count) { 1 }
+    #
+    #   include_examples "common tests"
+    # end
+    #
+    # context "with partial (treeless) clone" do
+    #   let!(:clone_method) { GitHelpers::CLONE_TREELESS }
+    #   let(:fetch_commit_count) { 3 }
+    #
+    #   include_examples "common tests"
+    # end
   end
 end

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+module GitHelpers
+  CLONE_FULL = :full
+  CLONE_SHALLOW = :shallow
+  CLONE_TREELESS = :treeless
+
+  class RemoteGitRepo
+    attr_reader :url, :work_path, :remote_path
+
+    def initialize(initial_branch: "main")
+      @initial_branch = initial_branch
+      @local_clone_count = 0
+      @root_path = Dir.mktmpdir
+
+      @remote_path = File.join(@root_path, "remote.git")
+      @url = "file://#{@remote_path}"
+
+      Dir.mkdir(@remote_path)
+      Dir.chdir(@remote_path) do
+        git "init --bare --initial-branch=#{initial_branch}"
+        git "config core.sharedrepository 1"
+        git "config receive.denyNonFastforwards true"
+        git "config receive.denyCurrentBranch ignore"
+        git "config uploadpack.allowFilter true"
+      end
+
+      @work_path = File.join(@root_path, "work")
+      Dir.mkdir(@work_path)
+      Dir.chdir(@work_path) do
+        git "init . --initial-branch=#{initial_branch}"
+        git "remote add origin #{@url}"
+
+        File.write("README.md", "This is a git repo for testing docker_manager.")
+        File.write("version.txt", "")
+
+        git "add ."
+        git "commit -m 'Initial commit'"
+        git "push --set-upstream origin #{initial_branch}"
+      end
+    end
+
+    def destroy
+      FileUtils.rm_rf(@root_path)
+    end
+
+    def create_local_clone(method:)
+      path = File.join(@root_path, "local_#{@local_clone_count}")
+
+      Dir.mkdir(path)
+      Dir.chdir(path) do
+        case (method)
+        when CLONE_FULL
+          git "clone #{@url} ."
+        when CLONE_SHALLOW
+          git "clone --depth 1 #{@url} ."
+        when CLONE_TREELESS
+          git "clone --filter=tree:0 #{@url} ."
+        end
+
+        yield(method(:git)) if block_given?
+      end
+
+      @local_clone_count += 1
+      LocalGitRepo.new(path, method)
+    end
+
+    def in_working_directory
+      Dir.chdir(@work_path) { yield(method(:git)) }
+    end
+
+    def in_remote_repo
+      Dir.chdir(@remote_path) { yield(method(:git)) }
+    end
+
+    def commit(filename:, commits:, branch: nil)
+      branch ||= @initial_branch
+
+      Dir.chdir(@work_path) do
+        git "checkout #{branch}"
+
+        commits.each do |commit|
+          env = commit[:date] ? build_env(date: commit[:date]) : nil
+          File.write(filename, commit[:content])
+
+          git "add #{filename}"
+          git "commit -m 'Update #{filename} with #{commit[:content].truncate(10)}'", env: env
+
+          if commit[:tags]
+            commit[:tags].each do |tag|
+              if git("tag -l #{tag}", raise_exception: false)
+                git "tag -d #{tag}"
+                git "push --delete origin #{tag}"
+              end
+
+              git "tag -a #{tag} -m 'Tagging #{tag}'"
+            end
+          end
+        end
+
+        git "push --follow-tags"
+      end
+    end
+
+    def create_branches(*branch_names)
+      Dir.chdir(@work_path) do
+        branch_names.each do |branch|
+          git "checkout #{@initial_branch}"
+          git "checkout -b #{branch}"
+          git "push --set-upstream origin #{branch}"
+        end
+      end
+    end
+
+    def delete_branches(*branch_names)
+      Dir.chdir(@work_path) do
+        branch_names.each do |branch|
+          git "checkout #{@initial_branch}"
+          git "branch -d #{branch}"
+          git "push origin --delete #{branch}"
+        end
+      end
+    end
+
+    def rename_branch(old_name:, new_name:)
+      Dir.chdir(@work_path) do
+        git "checkout #{old_name}"
+        git "branch -m #{new_name}"
+        git "push origin -u #{new_name}"
+
+        if old_name == @initial_branch
+          Dir.chdir(@remote_path) { git "symbolic-ref HEAD refs/heads/#{new_name}" }
+        end
+
+        git "push origin --delete #{old_name}"
+      end
+    end
+
+    def rebase(source_branch:, target_branch:)
+      Dir.chdir(@work_path) do
+        git "checkout #{target_branch}"
+        git "rebase #{source_branch}"
+        git "push --force"
+      end
+    end
+
+    def delete_tags(*tag_names)
+      Dir.chdir(@work_path) do
+        tag_names.each do |tag|
+          git "tag -d #{tag}"
+          git "push --delete origin #{tag}"
+        end
+      end
+    end
+
+    private
+
+    def git(command, env: "", raise_exception: true)
+      env = build_env if command.start_with?("commit") && env.blank?
+      result = `#{env} git #{command}`.strip
+
+      if $?.success? || !raise_exception
+        result = result.presence
+        puts result if result
+        result
+      else
+        raise RuntimeError
+      end
+    end
+
+    def build_env(name: "Alice", email: "alice@example.com", date: "2023-03-06T20:27:03Z")
+      "GIT_AUTHOR_NAME='#{name}' GIT_AUTHOR_EMAIL='#{email}' GIT_AUTHOR_DATE='#{date}' " \
+        "GIT_COMMITTER_NAME='#{name}' GIT_COMMITTER_EMAIL='#{email}' GIT_COMMITTER_DATE='#{date}'"
+    end
+  end
+
+  class LocalGitRepo
+    attr_reader :path
+
+    def initialize(path, clone_method)
+      @path = path
+      @clone_method = clone_method
+    end
+
+    def git(*commands)
+      Dir.chdir(@path) do
+        commands.map do |command|
+          result = `git #{command}`.strip
+          $?.success? ? result : (raise RuntimeError)
+        end
+      end
+    end
+
+    def commit_count
+      git("rev-list --all --count").first.to_i
+    end
+
+    def checkout(ref)
+      if @clone_method == CLONE_SHALLOW
+        git "remote set-branches origin #{ref}"
+        git "fetch --depth 1 origin #{ref}"
+      else
+        git "fetch origin #{ref}"
+      end
+
+      git "-c advice.detachedHead=false checkout #{ref}"
+    end
+  end
+end


### PR DESCRIPTION
* Detects when the tracked branch has been deleted from `origin` and forces a rebuild on the command line
* Allows updating when a tag is tracked and the tag was moved to a new commit
* Improves support for shallow clones
* Works with partial clones
* Adds lots of specs for git commands and replaces the existing specs. All specs use real git repositories instead of mocks