### PR TITLE
FIX: Update compatibility file for v3.1.0.beta1 and below

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,1 +1,4 @@
-3.1.0.beta1: 96211d622e15793574d94633f5ce4403f36b65ff
+# Do you need to make fixes for Discourse v3.1.0.beta1 and below?
+# Push to the `old-version-up-to-v3.1.0.beta1` branch, update the commit hash for "3.1.0.beta1"
+# in the line below and push this file to the `main` branch.
+3.1.0.beta1: 1b2d7eb0369155b6442b09adfb17b8942c04b093


### PR DESCRIPTION
Without this upgrades to v3.1.0.beta4+ will fail because those newer versions require Ruby 3.2 and the old, pinned docker_manager version didn't prompt for a CLI rebuild when upgrading from v3.1.0.beta1 and below.

See https://meta.discourse.org/t/runtime-error-during-upgrade-to-v3-0-3/262165

The actual fix is in 1b2d7eb0369155b6442b09adfb17b8942c04b093 which is part of the new [old-version-up-to-v3.1.0.beta1](https://github.com/discourse/docker_manager/tree/old-version-up-to-v3.1.0.beta1) branch.