### PR TITLE
FIX: Upgrading was broken when repo uses `master` branch

### DIFF
--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -70,8 +70,8 @@ class DockerManager::Upgrader
     # see http://stackoverflow.com/a/12699604/84283
     @repos.each_with_index do |repo, index|
       # We automatically handle renames from `master` -> `main`
-      if repo.upstream_branch == "origin/master" && repo.branch == "origin/main"
-        log "Branch has changed to #{repo.branch}"
+      if repo.upstream_branch == "origin/master" && repo.tracking_ref == "origin/main"
+        log "Branch has changed to #{repo.tracking_ref}"
 
         # Just in case `main` exists locally but is not used. Perhaps it was fetched?
         if repo.has_local_main?

--- a/spec/lib/git_repo_spec.rb
+++ b/spec/lib/git_repo_spec.rb
@@ -152,6 +152,32 @@ RSpec.describe DockerManager::GitRepo do
           it "returns the correct branch name" do
             expect(subject.upstream_branch).to eq("origin/tests-passed")
           end
+
+          context "with `master` as initial branch" do
+            let(:initial_branch) { "master" }
+
+            before { @after_local_repo_clone << -> { @local_repo.checkout("master") } }
+
+            it "returns `origin/master` if a repo hasn't been renamed" do
+              expect(subject.upstream_branch).to eq("origin/master")
+            end
+
+            it "returns `origin/master` if a repo has been renamed but still tracks `master`" do
+              @after_local_repo_clone << -> {
+                @remote_git_repo.rename_branch(old_name: "master", new_name: "main")
+              }
+
+              expect(subject.upstream_branch).to eq("origin/master")
+            end
+          end
+
+          context "with `main` as current local branch" do
+            before { @after_local_repo_clone << -> { @local_repo.checkout("main") } }
+
+            it "returns `origin/main` if a repo points at `origin/main`" do
+              expect(subject.upstream_branch).to eq("origin/main")
+            end
+          end
         end
 
         describe "#upstream_branch_exist?" do


### PR DESCRIPTION
See https://meta.discourse.org/t/upgrade-failure-docker-manager-bug/262404