### PR TITLE
FIX: Hide this plugin from the plugin list

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -7,6 +7,8 @@
 # authors: Robin Ward, Sam Saffron
 # url: https://github.com/discourse/docker_manager
 
+hide_plugin
+
 register_asset "stylesheets/common/docker-manager.scss"
 
 module ::DockerManager


### PR DESCRIPTION
This plugin is not optional and cannot be disabled,
it's essential for self-hosting, so there is no point
showing it in the plugin list.

![image](https://github.com/discourse/docker_manager/assets/920448/35ae9ca0-affd-4c56-8ae9-1eaeedb88b45)

