### PR TITLE
DEV: Use new JS plugin API to add admin sidebar link

### DIFF
--- a/admin/assets/javascripts/discourse/initializers/admin-sidebar-upgrade.js
+++ b/admin/assets/javascripts/discourse/initializers/admin-sidebar-upgrade.js
@@ -1,0 +1,17 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "docker-manager-admin-sidebar",
+  before: "admin-sidebar-initializer",
+
+  initialize() {
+    withPluginApi("1.24.0", (api) => {
+      api.addAdminSidebarSectionLink("root", {
+        name: "admin_upgrade",
+        route: "upgrade.index",
+        label: "admin.docker.upgrade_tab",
+        icon: "rocket",
+      });
+    });
+  },
+};


### PR DESCRIPTION
c.f. https://github.com/discourse/discourse/pull/25200

The new admin sidebar doesn't have plugin outlets, so we
need a way to register links like this Upgrade one. The
admin sidebar is currently experimental, so we need to keep
the old outlet around for now for sites who have not enabled
the admin sidebar.
