### PR TITLE
Bump minimum base image version

### DIFF
--- a/app/controllers/docker_manager/admin_controller.rb
+++ b/app/controllers/docker_manager/admin_controller.rb
@@ -47,7 +47,7 @@ module DockerManager
           end
 
         version = Gem::Version.new(version)
-        expected_version = Gem::Version.new("2.0.20230313-1023")
+        expected_version = Gem::Version.new("2.0.20240502-0021")
         ruby_version = Gem::Version.new(RUBY_VERSION)
         expected_ruby_version = Gem::Version.new("3.2.1")
         min_stable_version = Gem::Version.new("3.0.0")


### PR DESCRIPTION
The last forced update was more than a year ago. That old image has a lot of old dependencies, including an old `node` version which is no longer supported by some of Discourse's JS dependencies. This commit will instruct self-hosters to perform a command-line rebuild.