### PR TITLE
DEV: Print page's HTML at the end after test fails

### DIFF
--- a/spec/system/admin_update_spec.rb
+++ b/spec/system/admin_update_spec.rb
@@ -11,15 +11,11 @@ RSpec.describe "Admin update", type: :system do
   it "displays the admin update page with the right respositories" do
     visit("/admin/update")
 
-    # We are getting a blank page on CI so adding debugging steps to figure out why
-    if ENV["CI"]
-      expect(page).to have_current_path("/admin/update")
-      puts page.html
-    end
-
     expect(page).to have_css("h3", exact_text: I18n.t("js.admin.docker.update_title"))
     expect(page).to have_css("tr.repo .repo__name", exact_text: "Discourse")
     expect(page).to have_css("tr.repo .repo__name", exact_text: "Docker Manager")
     expect(page).to have_css("tr.repo .repo__about a[href='https://meta.discourse.org/t/12655']")
+  ensure
+    puts page.html if ENV["CI"]
   end
 end


### PR DESCRIPTION
This system spec is flaky and we are getting a blank page so I would
like to see what the HTML is. Previous printing of the page's HTML was
doing it too early such that the ember application has not even boot.
