### PR TITLE
DEV: Attempt to fix flaky system test

### DIFF
--- a/admin/assets/javascripts/discourse/routes/update-index.js
+++ b/admin/assets/javascripts/discourse/routes/update-index.js
@@ -1,18 +1,16 @@
 import Route from "@ember/routing/route";
 
 export default class UpgradeIndex extends Route {
-  model() {
-    return this.modelFor("update");
+  async model() {
+    const model = this.modelFor("update");
+    await this.loadRepos(model);
+    console.warn("loaded repos");
+    return model;
   }
 
   async loadRepos(list) {
     for (const repo of list) {
       await repo.findLatest();
     }
-  }
-
-  setupController(controller, model) {
-    super.setupController(...arguments);
-    this.loadRepos(model);
   }
 }

--- a/spec/system/admin_update_spec.rb
+++ b/spec/system/admin_update_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe "Admin update", type: :system do
 
   before { sign_in(admin) }
 
-  xit "displays the admin update page with the right respositories" do
+  it "displays the admin update page with the right respositories" do
     visit("/admin/update")
 
     expect(page).to have_css("h3", exact_text: I18n.t("js.admin.docker.update_title"))
     expect(page).to have_css("tr.repo .repo__name", exact_text: "Discourse")
     expect(page).to have_css("tr.repo .repo__name", exact_text: "Docker Manager")
     expect(page).to have_css("tr.repo .repo__about a[href='https://meta.discourse.org/t/12655']")
-  ensure
-    puts page.html if ENV["CI"]
   end
 end


### PR DESCRIPTION
The system test unskipped in this commit has been flaky because
a blank page is displayed when the `/admin/update` route is visited.
