### PR TITLE
DEV: Speed up /admin/docker/repos.json spec

### DIFF
--- a/spec/requests/admin_controller_spec.rb
+++ b/spec/requests/admin_controller_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe DockerManager::AdminController do
   end
 
   describe "#repos" do
+    before do
+      # Return only the first 3 repos to reduce the number of calls to 'git' CLI
+      repos = DockerManager::GitRepo.find_all
+      DockerManager::GitRepo.stubs(:find_all).returns(repos[0...3])
+    end
+
     it "should return the right response" do
       sign_in(Fabricate(:admin))
 


### PR DESCRIPTION
Requesting /admin/docker/repos.json with a lot of plugins installed can take a lot of time because of the large number of calls to the 'git' CLI that are used to retrieve various information about the plugin (eg. branch, latest commit, remote URL, etc).

This is not a problem in production because of memoization and the much lower number of installed plugins, but it is a problem in test environment where specs requesting this page can take 10+ seconds with ~100 installed plugins.

This commit speeds up by stubbing the `find_all` method to return only the first few repositories.