### PR TITLE
DEV: Optimize specs

### DIFF
--- a/spec/lib/git_repo_spec.rb
+++ b/spec/lib/git_repo_spec.rb
@@ -57,20 +57,23 @@ RSpec.describe DockerManager::GitRepo do
     def prepare_repos
       return if @local_repo && @remote_git_repo
 
-      @remote_git_repo = GitHelpers::RemoteGitRepo.new(initial_branch: initial_branch)
-      @remote_git_repo.commit(
-        filename: "foo.txt",
-        commits: [
-          { content: "A", date: "2023-03-06T20:31:17Z" },
-          {
-            content: "B",
-            date: "2023-03-06T21:08:52Z",
-            tags: %w[v3.1.0.beta1 beta latest-release],
-          },
-          { content: "C", date: "2023-03-06T22:48:29Z" },
-        ],
-      )
-      @remote_git_repo.create_branches("tests-passed")
+      @remote_git_repo =
+        GitHelpers::RemoteGitRepo.new(initial_branch: initial_branch) do |repo|
+          repo.commit(
+            filename: "foo.txt",
+            commits: [
+              { content: "A", date: "2023-03-06T20:31:17Z" },
+              {
+                content: "B",
+                date: "2023-03-06T21:08:52Z",
+                tags: %w[v3.1.0.beta1 beta latest-release],
+              },
+              { content: "C", date: "2023-03-06T22:48:29Z" },
+            ],
+          )
+
+          repo.create_branches("tests-passed")
+        end
 
       @before_local_repo_clone.each { |callback| callback.call }
       @local_repo = @remote_git_repo.create_local_clone(method: clone_method)

--- a/spec/lib/git_repo_spec.rb
+++ b/spec/lib/git_repo_spec.rb
@@ -58,13 +58,12 @@ RSpec.describe DockerManager::GitRepo do
       return if @local_repo && @remote_git_repo
 
       cache_key =
-        "#{initial_branch}-" + @before_local_repo_clone.map(&:source_location).flatten.join(",")
+        Digest::SHA1.hexdigest(
+          "#{initial_branch}-" + @before_local_repo_clone.map(&:source_location).flatten.join(","),
+        )
 
       @remote_git_repo =
-        GitHelpers::RemoteGitRepo.new(
-          initial_branch: initial_branch,
-          cache_key: Digest::SHA1.hexdigest(cache_key),
-        ) do |repo|
+        GitHelpers::RemoteGitRepo.new(initial_branch:, cache_key:) do |repo|
           repo.commit(
             filename: "foo.txt",
             commits: [

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -21,7 +21,7 @@ module GitHelpers
       if !force
         @@caches[cache_key] ||= self.class.new(initial_branch:, cache_key:, force: true, &blk)
         FileUtils.cp_r(@@caches[cache_key].root_path + "/.", @root_path)
-        Dir.chdir(@work_path) { git "remote remove origin && git remote add origin #{@url}" }
+        Dir.chdir(@work_path) { git "remote set-url origin #{@url}" }
         return
       end
 

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -10,21 +10,16 @@ module GitHelpers
 
     @@caches = {}
 
-    def initialize(initial_branch: "main", cache_key: nil, &blk)
+    def initialize(initial_branch: "main", cache_key: nil, force: false, &blk)
       @initial_branch = initial_branch
       @local_clone_count = 0
       @root_path = Dir.mktmpdir
-
-      @@caches[cache_key] ||= begin
-        @@caches[cache_key] = true
-        self.class.new(initial_branch: initial_branch, cache_key: cache_key, &blk)
-      end
-
       @remote_path = File.join(@root_path, "remote.git")
       @work_path = File.join(@root_path, "work")
       @url = "file://#{@remote_path}"
 
-      if @@caches[cache_key] != true
+      if !force
+        @@caches[cache_key] ||= self.class.new(initial_branch:, cache_key:, force: true, &blk)
         FileUtils.cp_r(@@caches[cache_key].root_path + "/.", @root_path)
         Dir.chdir(@work_path) { git "remote remove origin && git remote add origin #{@url}" }
         return

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -164,7 +164,7 @@ module GitHelpers
       if status.success? || !raise_exception
         stdout.presence
       else
-        raise RuntimeError
+        raise RuntimeError.new("stderr while running #{command}: #{stderr}")
       end
     end
 

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -23,12 +23,14 @@ module GitHelpers
         git "config receive.denyNonFastforwards true"
         git "config receive.denyCurrentBranch ignore"
         git "config uploadpack.allowFilter true"
+        git "config commit.gpgsign false"
       end
 
       @work_path = File.join(@root_path, "work")
       Dir.mkdir(@work_path)
       Dir.chdir(@work_path) do
         git "init . --initial-branch=#{initial_branch}"
+        git "config commit.gpgsign false"
         git "remote add origin #{@url}"
 
         File.write("README.md", "This is a git repo for testing docker_manager.")

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -10,22 +10,22 @@ module GitHelpers
 
     @@caches = {}
 
-    def initialize(initial_branch: "main", &blk)
+    def initialize(initial_branch: "main", cache_key: nil, &blk)
       @initial_branch = initial_branch
       @local_clone_count = 0
       @root_path = Dir.mktmpdir
 
-      @@caches[initial_branch] ||= begin
-        @@caches[initial_branch] = true
-        self.class.new(initial_branch: initial_branch, &blk)
+      @@caches[cache_key] ||= begin
+        @@caches[cache_key] = true
+        self.class.new(initial_branch: initial_branch, cache_key: cache_key, &blk)
       end
 
       @remote_path = File.join(@root_path, "remote.git")
       @work_path = File.join(@root_path, "work")
       @url = "file://#{@remote_path}"
 
-      if @@caches[initial_branch] != true
-        FileUtils.cp_r(@@caches[initial_branch].root_path + "/.", @root_path)
+      if @@caches[cache_key] != true
+        FileUtils.cp_r(@@caches[cache_key].root_path + "/.", @root_path)
         Dir.chdir(@work_path) { git "remote remove origin && git remote add origin #{@url}" }
         return
       end


### PR DESCRIPTION
Git repositories will be initialized less often and then copied for each
spec. This reduces the calls to 'git' and the total execution time of
the specs.