### PR TITLE
FIX: Remove <3.4.0.beta1 version pin

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,4 +1,3 @@
-< 3.4.0.beta1-dev: 38cdefa55a251f28e1a4b146ae79fc485f72d294
 < 3.3.0.beta1-dev: 9523f7a88453ce1863071bcc2bc88130b60efee5
 # Do you need to make fixes for Discourse v3.1.0.beta1 and below?
 # Push to the `old-version-up-to-v3.1.0.beta1` branch, update the commit hash for "3.1.0.beta1"


### PR DESCRIPTION
This pin means that sites will not show an update available for docker_manager, and will then hit a pnpm/yarn error when updating core.

docker_manager is compatible with the 3.3.x series, so we can remove this pin.