### PR TITLE
DEV: update the classname to match in core; success label tweak

### DIFF
--- a/admin/assets/javascripts/discourse/components/repo-status.gjs
+++ b/admin/assets/javascripts/discourse/components/repo-status.gjs
@@ -120,7 +120,7 @@ export default class RepoStatus extends Component {
         </div>
       </td>
 
-      <td class="d-admin-row__control">
+      <td class="d-admin-row__controls">
         {{#if @repo.checkingStatus}}
           <div class="status-label --loading">
             {{i18n "admin.docker.checking"}}

--- a/assets/stylesheets/common/docker-manager.scss
+++ b/assets/stylesheets/common/docker-manager.scss
@@ -157,7 +157,7 @@
 
     &.--success {
       background-color: var(--success-low);
-      padding: var(--space-1) var(--space-2);
+      padding: 0.8rem var(--space-2);
       border-radius: var(--d-border-radius);
 
       .status-label-indicator {


### PR DESCRIPTION
* Follow up to some class name changes in https://github.com/discourse/discourse/pull/29360
* Alignment tweak to the status label