### PR TITLE
FIX: Minimize database access following `db:migrate`

### DIFF
--- a/lib/docker_manager/upgrader.rb
+++ b/lib/docker_manager/upgrader.rb
@@ -3,6 +3,7 @@
 class DockerManager::Upgrader
   def initialize(user_id, repos, from_version)
     @user_id = user_id
+    @user = User.find(user_id)
     @repos = repos.is_a?(Array) ? repos : [repos]
     @from_version = from_version
   end
@@ -258,7 +259,8 @@ class DockerManager::Upgrader
   end
 
   def log_version_upgrade
-    StaffActionLogger.new(User.find(@user_id)).log_custom(
+    # Using cached user object to minimize database access after running migrations
+    StaffActionLogger.new(@user).log_custom(
       "discourse_update",
       from_version: @from_version,
       repository: @repos.map(&:path).join(", "),


### PR DESCRIPTION
The upgrade process was triggering the database migrations, and then calling `User.find()`. This is problematic because the `users` table may have been changed by the migrations, and accessing it with the 'old code' will raise an exception.

This commit tweaks the Upgrader so that it loads the user object into memory **before** running database migrations.