### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: e742d09454226b9138d55ba4b7f1ee935ab787f8
 < 3.3.0.beta1-dev: 9523f7a88453ce1863071bcc2bc88130b60efee5
 # Do you need to make fixes for Discourse v3.1.0.beta1 and below?
 # Push to the `old-version-up-to-v3.1.0.beta1` branch, update the commit hash for "3.1.0.beta1"

--- a/admin/assets/javascripts/discourse/components/repo-status.gjs
+++ b/admin/assets/javascripts/discourse/components/repo-status.gjs
@@ -69,7 +69,7 @@ export default class RepoStatus extends Component {
                 target="_blank"
               >
                 {{i18n "admin.plugins.learn_more"}}
-                {{icon "external-link-alt"}}
+                {{icon "up-right-from-square"}}
               </a>
             {{/if}}
           </div>


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.