### PR TITLE
UX: Badge styling tweaks

### DIFF
--- a/assets/stylesheets/common/docker-manager.scss
+++ b/assets/stylesheets/common/docker-manager.scss
@@ -114,8 +114,8 @@
     margin-bottom: var(--space-6);
   }
 
-  tr.repo {
-    td:first-child {
+  .d-admin-row__content.repo {
+    .d-admin-row__overview {
       width: 45%;
 
       @include breakpoint("tablet") {
@@ -123,8 +123,9 @@
       }
     }
 
-    td:last-child {
+    .d-admin-row__controls {
       width: 12%; // set width to minimize layout shift
+      text-align: left;
 
       @include breakpoint("tablet") {
         width: auto;
@@ -144,36 +145,20 @@
   }
 
   .status-label {
-    --d-border-radius: 0.75rem;
-    --success-low: #f5fff5;
-
-    display: flex;
-    flex-wrap: nowrap;
-    width: fit-content;
-
     &.--loading {
+      background-color: transparent;
       color: var(--primary-medium);
     }
 
     &.--success {
       background-color: var(--success-low);
-      padding: 0.8rem var(--space-2);
-      border-radius: var(--d-border-radius);
 
       .status-label-indicator {
-        display: inline-block;
-        width: 6px;
-        height: 6px;
-        border-radius: 50%;
         background-color: var(--success);
-        flex-shrink: 0;
-        margin-right: var(--space-1);
-        margin-top: 0.4rem;
       }
 
       .status-label-text {
-        color: var(--success);
-        font-size: var(--font-down-1);
+        color: var(--primary-very-high);
       }
     }
   }


### PR DESCRIPTION
Removed the hardcoded padding and hex value for the `--success-low` variable

### Before
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/6c6df6dd-5c87-4d60-9156-8b1939ec6c82">

### After
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/554e8c50-fc1b-49cf-bbf1-c9357a747874">

Related: moved the badge styling to core: https://github.com/discourse/discourse/pull/30125