### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/admin/assets/javascripts/discourse/templates/update.hbs
+++ b/admin/assets/javascripts/discourse/templates/update.hbs
@@ -22,7 +22,7 @@
       <div id="banner-content">
         <div class="floated-buttons">
           <DButton
-            @icon="times"
+            @icon="xmark"
             @action={{this.dismiss}}
             @title="banner.close"
             class="btn btn-flat close"


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.