### PR TITLE
UX: Removed a redundant git pull statement from the user message

### DIFF
--- a/admin/assets/javascripts/discourse/templates/update-index.hbs
+++ b/admin/assets/javascripts/discourse/templates/update-index.hbs
@@ -23,7 +23,6 @@
   {{! prettier-ignore }}
   <pre>
     cd /var/discourse
-    git pull
     ./launcher rebuild app
   </pre>
   <p>


### PR DESCRIPTION
The message that tells the users how to upgrade shows a redundant `git pull` that is not needed anymore.