### PR TITLE
DEV: Skip core features specs on stable

### DIFF
--- a/spec/system/core_features_spec.rb
+++ b/spec/system/core_features_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe "Core features", type: :system do
+  # TODO: Stop skipping when shared example is available in stable
+  next if Discourse.git_branch == "stable"
+
   before { enable_current_plugin }
 
   it_behaves_like "having working core features"


### PR DESCRIPTION
The shared example is not available in stable yet and is causing the builds for the stable branch in `discourse/discourse` to fail since this is an official plugin.