### PR TITLE
DEV: Add `ci-stable` job

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -9,3 +9,8 @@ on:
 jobs:
   ci:
     uses: discourse/.github/.github/workflows/discourse-plugin.yml@v1
+
+  ci-stable:
+    uses: discourse/.github/.github/workflows/discourse-plugin.yml@v1
+    with:
+      core_ref: stable

--- a/spec/system/core_features_spec.rb
+++ b/spec/system/core_features_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe "Core features", type: :system do
-  # TODO: Stop skipping when shared example is available in stable
-  next if Discourse.git_branch == "stable"
+# TODO: Stop skipping when shared example is available in stable
+# RSpec.describe "Core features", type: :system do
+#   before { enable_current_plugin }
 
-  before { enable_current_plugin }
-
-  it_behaves_like "having working core features"
-end
+#   it_behaves_like "having working core features"
+# end


### PR DESCRIPTION
This plugin is important so we want to ensure that the tests pass
against the `stable` branch too.
