### PR TITLE
DEV: Enable smoke specs again

### DIFF
--- a/spec/system/core_features_spec.rb
+++ b/spec/system/core_features_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# TODO: Stop skipping when shared example is available in stable
-# RSpec.describe "Core features", type: :system do
-#   before { enable_current_plugin }
+RSpec.describe "Core features", type: :system do
+  before { enable_current_plugin }
 
-#   it_behaves_like "having working core features"
-# end
+  it_behaves_like "having working core features"
+end


### PR DESCRIPTION
Now that `stable` provides the smoke specs, we can enable them again for this plugin.