### PR TITLE
DEV: Add `docker_manager:stop_all_upgrades` rake task

### DIFF
--- a/lib/tasks/docker_manager.rake
+++ b/lib/tasks/docker_manager.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../docker_manager/web_server_adapter"
+
+namespace :docker_manager do
+  desc "Clear Redis flags that would otherwise leave the web upgrade UI stuck. Invoked by discourse_docker after a full rebuild."
+  task stop_all_upgrades: :environment do
+    RailsMultisite::ConnectionManagement.each_connection do
+      Discourse.redis.scan_each(match: "upgrade:*") { |key| Discourse.redis.del(key) }
+      Discourse.redis.del(DockerManager::WebServerAdapter::RESTART_FLAG_KEY)
+    end
+  end
+end


### PR DESCRIPTION
**Previously**, there was no way to clear the Redis flags that drive the web upgrade UI state, so a failed web update followed by a manual `./launcher rebuild app` could leave the admin interface stuck on "Updating...".

**In this update**, adds a rake task that clears `upgrade:*` keys and the `docker_manager:upgrade:server_restarting` flag across all sites. Intended to be invoked from `discourse_docker`'s `web.template.yml` so the UI state is reset after a full container rebuild.