### PR TITLE
UX: add missing class to buttons

### DIFF
--- a/admin/assets/javascripts/discourse/templates/update/show.gjs
+++ b/admin/assets/javascripts/discourse/templates/update/show.gjs
@@ -28,7 +28,7 @@ export default <template>
       <button
         {{on "click" @controller.start}}
         disabled={{@controller.upgrading}}
-        class="btn start-upgrade"
+        class="btn btn-default start-upgrade"
         type="button"
       >
         {{#if @controller.upgrading}}
@@ -41,7 +41,7 @@ export default <template>
       {{#if @controller.upgrading}}
         <button
           {{on "click" @controller.resetUpgrade}}
-          class="btn unlock"
+          class="btn btn-default unlock"
           type="button"
         >
           {{i18n "admin.docker.reset_update"}}


### PR DESCRIPTION
a couple buttons here missing the `btn-default` class which is needed to pick up our standard button styles 